### PR TITLE
Fix libappindicator1 install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,8 @@ FROM python:3.7
 
 # Install manually all the missing libraries
 RUN apt-get update
-RUN apt-get install -y gconf-service libasound2 libatk1.0-0 libcairo2 libcups2 libfontconfig1 libgdk-pixbuf2.0-0 libgtk-3-0 libnspr4 libpango-1.0-0 libxss1 fonts-liberation libappindicator1 libnss3 lsb-release xdg-utils
+RUN apt-get install -y gconf-service libasound2 libatk1.0-0 libcairo2 libcups2 libfontconfig1 libgdk-pixbuf2.0-0 libgtk-3-0 libnspr4 libpango-1.0-0 libxss1 fonts-liberation libnss3 lsb-release xdg-utils
+RUN apt-get install -y libappindicator1; apt-get -fy install
 
 # Install Chrome
 RUN wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb


### PR DESCRIPTION
Most recent versions of docker returns an error message when building the Dockerfile: 
**'Error E: Unable to locate package libappindicator1'**.
Adding the line ```RUN apt-get install -y libappindicator1; apt-get -fy install``` solves this problem.